### PR TITLE
Deployed but app runs with error

### DIFF
--- a/src/components/QuoteComponent.js
+++ b/src/components/QuoteComponent.js
@@ -113,8 +113,8 @@ class QuoteComponent extends React.Component {
     let containerBgColor = `alert-${this.bgColor}`;
     const tweetUrl = `https://twitter.com/intent/tweet?hashtags=quotes&related=freecodecamp&text=${this.state.quote.text}`;
     return(
-      // <div ref={this.wrapper}>
       <div>
+        {/* <div ref={this.wrapper}> */}
         <GoogleFontLoader
           fonts={[
             {


### PR DESCRIPTION
Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null.